### PR TITLE
feat: Configure Railway deployment (health endpoint + migrations)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -3,9 +3,11 @@ URL configuration for timecomply project.
 """
 
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
 
 urlpatterns = [
+    path("health/", lambda request: HttpResponse("ok")),
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
     path("api/", include("apps.api.urls")),

--- a/railway.json
+++ b/railway.json
@@ -6,6 +6,7 @@
   "deploy": {
     "startCommand": "gunicorn config.wsgi:application --bind 0.0.0.0:$PORT",
     "healthcheckPath": "/health/",
-    "restartPolicyType": "ON_FAILURE"
+    "restartPolicyType": "ON_FAILURE",
+    "releaseCommand": "python manage.py migrate --noinput"
   }
 }


### PR DESCRIPTION
Implements remaining code changes for Railway deployment setup.

## Changes
- Add `/health/` endpoint to `config/urls.py` returning HTTP 200 "ok"
- Add `releaseCommand` to `railway.json` to run `migrate --noinput` before each deployment

Closes #3

Generated with [Claude Code](https://claude.ai/code)