### PR TITLE
feat: Employee dashboard and timesheet list view (#24)

### DIFF
--- a/apps/timesheets/urls.py
+++ b/apps/timesheets/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("timesheets/presets/", views.preset_manage, name="preset_manage"),
     path("timesheets/<uuid:pk>/", views.weekly_view, name="weekly"),
     path("timesheets/<uuid:pk>/submit/", views.submit_confirm, name="submit_confirm"),
+    path("timesheets/<uuid:pk>/revise/", views.timesheet_revise, name="revise"),
     # Period management
     path("periods/", views.period_list, name="periods"),
     path("periods/create/", views.period_create, name="period_create"),

--- a/apps/timesheets/views.py
+++ b/apps/timesheets/views.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.mail import send_mail
+from django.db.models import Sum
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 
@@ -103,8 +104,7 @@ def _build_grid(timesheet, period_dates, company, user):
     grid = []
     for cat in all_cats:
         cells = [
-            {"date": d, "entry": entry_map.get(cat, {}).get(d)}
-            for d in period_dates
+            {"date": d, "entry": entry_map.get(cat, {}).get(d)} for d in period_dates
         ]
         row_total = sum(
             c["entry"].hours
@@ -130,6 +130,63 @@ def _build_grid(timesheet, period_dates, company, user):
 
     grand_total = sum(col_totals)
     return grid, col_totals, grand_total, all_cats
+
+
+@login_required
+def dashboard(request):
+    company = request.company
+    membership = getattr(request.user, "membership", None)
+
+    if not membership or not membership.is_employee:
+        return render(
+            request,
+            "dashboard.html",
+            {"membership": membership, "is_employee": False},
+        )
+
+    open_due_periods(company)
+    current_period = get_current_period(company)
+
+    current_timesheet = None
+    today_hours = 0
+    if current_period:
+        try:
+            current_timesheet = Timesheet.objects.get(
+                employee=request.user,
+                period=current_period,
+                company=company,
+            )
+            today_hours = (
+                current_timesheet.entries.filter(date=date.today()).aggregate(
+                    total=Sum("hours")
+                )["total"]
+                or 0
+            )
+        except Timesheet.DoesNotExist:
+            current_timesheet = None
+
+    rejected_timesheets = (
+        Timesheet.objects.filter(
+            employee=request.user,
+            company=company,
+            status="rejected",
+        )
+        .select_related("period")
+        .order_by("-period__start_date")
+    )
+
+    return render(
+        request,
+        "dashboard.html",
+        {
+            "membership": membership,
+            "is_employee": True,
+            "current_period": current_period,
+            "current_timesheet": current_timesheet,
+            "today_hours": today_hours,
+            "rejected_timesheets": rejected_timesheets,
+        },
+    )
 
 
 @login_required
@@ -441,6 +498,7 @@ def submit_confirm(request, pk):
 @login_required
 def timesheet_list(request):
     company = request.company
+    membership = getattr(request.user, "membership", None)
     timesheets = (
         Timesheet.objects.filter(employee=request.user, company=company)
         .select_related("period")
@@ -449,8 +507,35 @@ def timesheet_list(request):
     return render(
         request,
         "timesheets/list.html",
-        {"timesheets": timesheets},
+        {"timesheets": timesheets, "membership": membership},
     )
+
+
+@login_required
+def timesheet_revise(request, pk):
+    company = request.company
+    timesheet = get_object_or_404(
+        Timesheet, pk=pk, company=company, employee=request.user
+    )
+
+    membership = getattr(request.user, "membership", None)
+    if not membership or not membership.is_employee:
+        messages.error(request, "Only employees can revise timesheets.")
+        return redirect("timesheets:list")
+
+    if timesheet.status != "rejected":
+        messages.error(request, "Only rejected timesheets can be revised.")
+        return redirect("timesheets:list")
+
+    if request.method == "POST":
+        timesheet.status = "draft"
+        timesheet.save()
+        messages.success(
+            request, "Timesheet returned to draft. You can now edit and resubmit."
+        )
+        return redirect(f"/timesheets/enter/?period={timesheet.period.pk}")
+
+    return redirect("timesheets:list")
 
 
 # ---------------------------------------------------------------------------

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,7 +6,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
 
-from apps.companies.views import dashboard
+from apps.timesheets.views import dashboard
 
 urlpatterns = [
     path("health/", lambda request: HttpResponse("ok")),

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,2 +1,46 @@
 /* TimeComply custom CSS overrides */
 /* Add custom styles here to override Milligram defaults */
+
+/* Status badges */
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 0.85em;
+    font-weight: bold;
+}
+
+.badge-draft    { background: #eee; color: #333; }
+.badge-submitted { background: #fff3cd; color: #856404; }
+.badge-approved  { background: #d4edda; color: #155724; }
+.badge-rejected  { background: #f8d7da; color: #721c24; }
+.badge-locked    { background: #343a40; color: #fff; }
+
+/* Notice boxes */
+.notice {
+    padding: 0.8rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    border: 1px solid #ddd;
+    background: #f8f9fa;
+}
+
+.notice-warning {
+    background: #fff3cd;
+    border-color: #ffc107;
+    color: #856404;
+}
+
+.notice-info {
+    background: #d1ecf1;
+    border-color: #bee5eb;
+    color: #0c5460;
+}
+
+/* Small button variant */
+.button-small {
+    font-size: 1rem;
+    height: 2.8rem;
+    line-height: 2.8rem;
+    padding: 0 1.2rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,9 +16,12 @@
     <header>
         <nav class="navigation">
             <div class="container">
-                <a href="/" class="navigation-title">TimeComply</a>
+                <a href="/dashboard/" class="navigation-title">TimeComply</a>
                 <ul class="navigation-list">
                     {% if user.is_authenticated %}
+                        <li class="navigation-item"><a href="/dashboard/">Dashboard</a></li>
+                        <li class="navigation-item"><a href="/timesheets/enter/">Enter Time</a></li>
+                        <li class="navigation-item"><a href="/timesheets/">My Timesheets</a></li>
                         <li class="navigation-item"><a href="/accounts/logout/">Logout</a></li>
                     {% else %}
                         <li class="navigation-item"><a href="/accounts/login/">Login</a></li>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,10 +6,97 @@
 <div class="row">
   <div class="column">
     <h2>Dashboard</h2>
-    {% if request.company %}
-      <p>Welcome to <strong>{{ request.company.name }}</strong>.</p>
+
+    {% if not is_employee %}
+      <div class="notice">
+        <p>You do not have timesheet requirements for this company.</p>
+        {% if membership %}
+          <p>Based on your roles, you can access:</p>
+          <ul>
+            {% if membership.is_approver or membership.is_admin %}
+              <li><a href="/approvals/">Approval Setup</a></li>
+            {% endif %}
+            {% if membership.is_period_manager or membership.is_admin %}
+              <li><a href="{% url 'timesheets:periods' %}">Pay Periods</a></li>
+            {% endif %}
+            {% if membership.is_admin %}
+              <li><a href="{% url 'companies:settings' %}">Company Settings</a></li>
+              <li><a href="{% url 'companies:members' %}">Members</a></li>
+            {% endif %}
+          </ul>
+        {% else %}
+          <p>You are not a member of any company. <a href="{% url 'companies:register' %}">Register a company</a>.</p>
+        {% endif %}
+      </div>
+
+    {% else %}
+      {# Employee dashboard #}
+      <div class="row">
+        <div class="column">
+          {% if current_period %}
+            <h4>Current Pay Period</h4>
+            <p>{{ current_period.start_date }} — {{ current_period.end_date }}</p>
+
+            <p><strong>Today's hours:</strong> {{ today_hours }}</p>
+
+            {% if current_timesheet %}
+              <p>
+                <strong>Timesheet status:</strong>
+                <span class="badge badge-{{ current_timesheet.status }}">{{ current_timesheet.get_status_display }}</span>
+              </p>
+
+              {% if current_timesheet.status == "rejected" %}
+                <div class="notice notice-warning">
+                  <strong>Timesheet rejected</strong>
+                  {% if current_timesheet.rejection_reason %} — {{ current_timesheet.rejection_reason }}{% endif %}
+                  <form method="post" action="{% url 'timesheets:revise' current_timesheet.pk %}" style="display:inline; margin-left:0.8rem;">
+                    {% csrf_token %}
+                    <button type="submit" class="button button-outline button-small">Revise</button>
+                  </form>
+                </div>
+              {% endif %}
+
+              {% if current_timesheet.status == "draft" %}
+                <p>
+                  <a href="{% url 'timesheets:entry' %}" class="button button-small">Enter Time</a>
+                </p>
+              {% endif %}
+
+            {% else %}
+              <p>No timesheet started yet for this period.</p>
+              <p>
+                <a href="{% url 'timesheets:entry' %}" class="button button-small">Enter Time</a>
+              </p>
+            {% endif %}
+
+          {% else %}
+            <div class="notice notice-warning">
+              <p>No active pay period. Contact your administrator.</p>
+            </div>
+          {% endif %}
+
+          <p>
+            <a href="{% url 'timesheets:list' %}" class="button button-outline button-small">My Timesheets</a>
+          </p>
+        </div>
+      </div>
+
+      {% if rejected_timesheets %}
+        {% for ts in rejected_timesheets %}
+          {% if ts != current_timesheet %}
+            <div class="notice notice-warning">
+              <strong>Action required:</strong> Timesheet for {{ ts.period.start_date }} — {{ ts.period.end_date }} was rejected.
+              {% if ts.rejection_reason %} Reason: {{ ts.rejection_reason }}{% endif %}
+              <form method="post" action="{% url 'timesheets:revise' ts.pk %}" style="display:inline; margin-left:0.8rem;">
+                {% csrf_token %}
+                <button type="submit" class="button button-outline button-small">Revise</button>
+              </form>
+            </div>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+
     {% endif %}
-    <p>More features coming soon.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/timesheets/list.html
+++ b/templates/timesheets/list.html
@@ -8,6 +8,7 @@
     <h2>My Timesheets</h2>
 
     <p>
+      <a href="/dashboard/" class="button button-outline button-small">Dashboard</a>
       <a href="{% url 'timesheets:entry' %}" class="button button-outline button-small">Enter Time</a>
     </p>
 
@@ -16,7 +17,6 @@
         <thead>
           <tr>
             <th>Period</th>
-            <th>Type</th>
             <th>Status</th>
             <th>Submitted</th>
             <th>Actions</th>
@@ -28,27 +28,30 @@
               <td style="white-space:nowrap;">
                 {{ ts.period.start_date }} — {{ ts.period.end_date }}
               </td>
-              <td>{{ ts.period.get_period_type_display }}</td>
               <td>
-                {% if ts.status == "draft" %}
-                  <span style="background:#eee; padding:2px 8px; border-radius:3px;">Draft</span>
-                {% elif ts.status == "submitted" %}
-                  <span style="background:#d4edda; color:#155724; padding:2px 8px; border-radius:3px;">Submitted</span>
-                {% elif ts.status == "approved" %}
-                  <span style="background:#cce5ff; color:#004085; padding:2px 8px; border-radius:3px;">Approved</span>
-                {% elif ts.status == "rejected" %}
-                  <span style="background:#f8d7da; color:#721c24; padding:2px 8px; border-radius:3px;">Rejected</span>
-                {% elif ts.status == "locked" %}
-                  <span style="background:#343a40; color:#fff; padding:2px 8px; border-radius:3px;">Locked</span>
-                {% else %}
-                  {{ ts.get_status_display }}
-                {% endif %}
+                <span class="badge badge-{{ ts.status }}">{{ ts.get_status_display }}</span>
               </td>
               <td>{{ ts.submitted_at|date:"N j, Y"|default:"—" }}</td>
               <td>
                 <a href="{% url 'timesheets:weekly' ts.pk %}">View</a>
+                {% if ts.status == "rejected" and membership.is_employee %}
+                  &nbsp;
+                  <form method="post" action="{% url 'timesheets:revise' ts.pk %}" style="display:inline;">
+                    {% csrf_token %}
+                    <button type="submit" class="button button-outline button-small">Revise</button>
+                  </form>
+                {% endif %}
               </td>
             </tr>
+            {% if ts.status == "rejected" and ts.rejection_reason %}
+              <tr>
+                <td colspan="4">
+                  <div class="notice notice-warning" style="margin:0 0 0.5rem 0; padding:0.5rem 0.8rem;">
+                    <strong>Rejection reason:</strong> {{ ts.rejection_reason }}
+                  </div>
+                </td>
+              </tr>
+            {% endif %}
           {% endfor %}
         </tbody>
       </table>

--- a/tests/timesheets/test_dashboard.py
+++ b/tests/timesheets/test_dashboard.py
@@ -1,0 +1,263 @@
+"""Tests for the dashboard view and timesheet revise view."""
+
+from datetime import date, timedelta
+
+import pytest
+from django.test import Client
+
+from tests.companies.factories import (
+    CompanyFactory,
+    CompanyMembershipFactory,
+    UserFactory,
+)
+from tests.projects.factories import ProjectFactory
+from tests.timesheets.factories import (
+    TimeEntryFactory,
+    TimePeriodFactory,
+    TimesheetFactory,
+)
+
+
+@pytest.fixture
+def company():
+    return CompanyFactory()
+
+
+@pytest.fixture
+def employee(company):
+    user = UserFactory()
+    CompanyMembershipFactory(user=user, company=company, is_employee=True)
+    return user
+
+
+@pytest.fixture
+def non_employee(company):
+    user = UserFactory()
+    CompanyMembershipFactory(
+        user=user, company=company, is_employee=False, is_admin=True
+    )
+    return user
+
+
+@pytest.fixture
+def period(company):
+    today = date.today()
+    return TimePeriodFactory(
+        company=company,
+        start_date=today,
+        end_date=today + timedelta(days=6),
+        status="open",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard view tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_login():
+    client = Client()
+    response = client.get("/dashboard/")
+    assert response.status_code == 302
+    assert "/accounts/login/" in response["Location"]
+
+
+@pytest.mark.django_db
+def test_dashboard_employee_with_open_period(company, employee, period):
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"Current Pay Period" in response.content
+    assert response.context["current_period"] == period
+
+
+@pytest.mark.django_db
+def test_dashboard_employee_no_period(company, employee):
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"No active pay period" in response.content
+
+
+@pytest.mark.django_db
+def test_dashboard_non_employee_shows_no_timesheet_message(company, non_employee):
+    client = Client()
+    client.force_login(non_employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"do not have timesheet requirements" in response.content
+
+
+@pytest.mark.django_db
+def test_dashboard_shows_current_timesheet_status(company, employee, period):
+    TimesheetFactory(
+        employee=employee, company=company, period=period, status="submitted"
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"Submitted" in response.content
+
+
+@pytest.mark.django_db
+def test_dashboard_shows_rejected_reason_and_revise(company, employee, period):
+    TimesheetFactory(
+        employee=employee,
+        company=company,
+        period=period,
+        status="rejected",
+        rejection_reason="Missing charge codes.",
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"Missing charge codes." in response.content
+    assert b"Revise" in response.content
+
+
+@pytest.mark.django_db
+def test_dashboard_shows_today_hours(company, employee, period):
+    project = ProjectFactory(company=company)
+    timesheet = TimesheetFactory(employee=employee, company=company, period=period)
+    TimeEntryFactory(
+        timesheet=timesheet,
+        labor_category=project,
+        date=date.today(),
+        hours=6,
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"6" in response.content
+
+
+@pytest.mark.django_db
+def test_dashboard_non_employee_shows_admin_links(company, non_employee):
+    client = Client()
+    client.force_login(non_employee)
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    assert b"Company Settings" in response.content
+    assert b"Members" in response.content
+
+
+# ---------------------------------------------------------------------------
+# Timesheet revise view tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_revise_rejected_timesheet(company, employee, period):
+    timesheet = TimesheetFactory(
+        employee=employee, company=company, period=period, status="rejected"
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.post(f"/timesheets/{timesheet.pk}/revise/")
+    assert response.status_code == 302
+    timesheet.refresh_from_db()
+    assert timesheet.status == "draft"
+
+
+@pytest.mark.django_db
+def test_revise_non_rejected_timesheet_blocked(company, employee, period):
+    timesheet = TimesheetFactory(
+        employee=employee, company=company, period=period, status="submitted"
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.post(f"/timesheets/{timesheet.pk}/revise/")
+    assert response.status_code == 302
+    timesheet.refresh_from_db()
+    assert timesheet.status == "submitted"
+
+
+@pytest.mark.django_db
+def test_revise_redirects_to_entry_view(company, employee, period):
+    timesheet = TimesheetFactory(
+        employee=employee, company=company, period=period, status="rejected"
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.post(f"/timesheets/{timesheet.pk}/revise/")
+    assert response.status_code == 302
+    assert "/timesheets/enter/" in response["Location"]
+
+
+@pytest.mark.django_db
+def test_revise_non_employee_blocked(company, period):
+    user = UserFactory()
+    CompanyMembershipFactory(user=user, company=company, is_employee=False)
+    timesheet = TimesheetFactory(
+        employee=user, company=company, period=period, status="rejected"
+    )
+    client = Client()
+    client.force_login(user)
+    response = client.post(f"/timesheets/{timesheet.pk}/revise/")
+    assert response.status_code == 302
+    timesheet.refresh_from_db()
+    assert timesheet.status == "rejected"
+
+
+@pytest.mark.django_db
+def test_revise_other_employee_timesheet_404(company, employee, period):
+    other = UserFactory()
+    CompanyMembershipFactory(user=other, company=company, is_employee=True)
+    timesheet = TimesheetFactory(
+        employee=other, company=company, period=period, status="rejected"
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.post(f"/timesheets/{timesheet.pk}/revise/")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Timesheet list scoping tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_timesheet_list_scoped_to_employee(company, employee, period):
+    other = UserFactory()
+    CompanyMembershipFactory(user=other, company=company, is_employee=True)
+    my_ts = TimesheetFactory(employee=employee, company=company, period=period)
+    other_period = TimePeriodFactory(
+        company=company,
+        start_date=date.today() - timedelta(days=14),
+        end_date=date.today() - timedelta(days=8),
+        status="closed",
+    )
+    TimesheetFactory(employee=other, company=company, period=other_period)
+
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/timesheets/")
+    assert response.status_code == 200
+    timesheets = list(response.context["timesheets"])
+    # Employee sees only their own timesheet
+    assert len(timesheets) == 1
+    assert timesheets[0].pk == my_ts.pk
+
+
+@pytest.mark.django_db
+def test_timesheet_list_shows_rejection_reason(company, employee, period):
+    TimesheetFactory(
+        employee=employee,
+        company=company,
+        period=period,
+        status="rejected",
+        rejection_reason="Hours do not add up.",
+    )
+    client = Client()
+    client.force_login(employee)
+    response = client.get("/timesheets/")
+    assert response.status_code == 200
+    assert b"Hours do not add up." in response.content
+    assert b"Revise" in response.content


### PR DESCRIPTION
Implements issue #24: employee-facing dashboard and timesheet list view.

## Changes
- Employee dashboard at `/dashboard/` with current period, today's hours, timesheet status, and action items for rejected timesheets
- Non-employee landing page with role-appropriate links
- Timesheet list with color-coded CSS status badges and inline rejection reasons
- "Revise" button to reset rejected timesheets back to draft
- Updated top navigation with Dashboard, Enter Time, My Timesheets links
- 15 new unit tests

Closes #24

Generated with [Claude Code](https://claude.ai/code)